### PR TITLE
Fixed an issue where an error occurred when entering a mask

### DIFF
--- a/nodes_one.py
+++ b/nodes_one.py
@@ -331,7 +331,7 @@ class FramePackSingleFrameSampler:
                         )
                         input_mask_resized = input_mask_resized.to(
                             clean_latents_pre.device
-                        )[None, None, None, :, :]
+                        )[None, None, :, :]
                         clean_latents_pre = clean_latents_pre * input_mask_resized
                         print("入力画像マスクを適用しました")
                     except Exception as e:
@@ -368,7 +368,7 @@ class FramePackSingleFrameSampler:
                         )
                         reference_mask_resized = reference_mask_resized.to(
                             clean_latents_post.device
-                        )[None, None, None, :, :]
+                        )[None, None, :, :]
                         clean_latents_post = clean_latents_post * reference_mask_resized
                         print("参照画像マスクを適用しました")
                     except Exception as e:


### PR DESCRIPTION
Hello.

`FramePack Signe Frame Sampler` has `input_mask` and `reference_mask` as inputs, and when I connected `mask` output nodes to them and run, I got the following error:

<details>

# ComfyUI Error Report
## Error Details
- **Node ID:** 107
- **Node Type:** FramePackSingleFrameSampler
- **Exception Type:** RuntimeError
- **Exception Message:** Expected 4D (unbatched) or 5D (batched) input to conv3d, but got input of size: [1, 1, 32, 1, 166, 96]
## Stack Trace
```
  File "C:\sd\ComfyUI\execution.py", line 349, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)

  File "C:\sd\ComfyUI\execution.py", line 224, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)

  File "C:\sd\ComfyUI\execution.py", line 196, in _map_node_over_list
    process_inputs(input_dict, i)

  File "C:\sd\ComfyUI\execution.py", line 185, in process_inputs
    results.append(getattr(obj, func)(**inputs))

  File "C:\sd\ComfyUI\custom_nodes\ComfyUI-FramePackWrapper_PlusOne\nodes_one.py", line 517, in process
    generated_latents = sample_hunyuan(

  File "C:\sd\ComfyUI\venv\lib\site-packages\torch\utils\_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)

  File "C:\sd\ComfyUI\custom_nodes\ComfyUI-FramePackWrapper_PlusOne\diffusers_helper\pipelines\k_diffusion_hunyuan.py", line 119, in sample_hunyuan
    results = sample_unipc(k_model, latents, sigmas, extra_args=sampler_kwargs, disable=False, variant=variant, callback=callback)

  File "C:\sd\ComfyUI\custom_nodes\ComfyUI-FramePackWrapper_PlusOne\diffusers_helper\k_diffusion\uni_pc_fm.py", line 149, in sample_unipc
    return FlowMatchUniPC(model, extra_args=extra_args, variant=variant).sample(noise, sigmas=sigmas, callback=callback, disable_pbar=disable)

  File "C:\sd\ComfyUI\custom_nodes\ComfyUI-FramePackWrapper_PlusOne\diffusers_helper\k_diffusion\uni_pc_fm.py", line 119, in sample
    model_prev_list = [self.model_fn(x, vec_t)]

  File "C:\sd\ComfyUI\custom_nodes\ComfyUI-FramePackWrapper_PlusOne\diffusers_helper\k_diffusion\uni_pc_fm.py", line 23, in model_fn
    return self.model(x, t, **self.extra_args)

  File "C:\sd\ComfyUI\custom_nodes\ComfyUI-FramePackWrapper_PlusOne\diffusers_helper\k_diffusion\wrapper.py", line 37, in k_model
    pred_positive = transformer(hidden_states=hidden_states, timestep=timestep, return_dict=False, **extra_args['positive'])[0].float()

  File "C:\sd\ComfyUI\venv\lib\site-packages\torch\nn\modules\module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)

  File "C:\sd\ComfyUI\venv\lib\site-packages\torch\nn\modules\module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)

  File "C:\sd\ComfyUI\custom_nodes\ComfyUI-FramePackWrapper_PlusOne\diffusers_helper\models\hunyuan_video_packed.py", line 900, in forward
    hidden_states, rope_freqs = self.process_input_hidden_states(hidden_states, latent_indices, clean_latents, clean_latent_indices, clean_latents_2x, clean_latent_2x_indices, clean_latents_4x, clean_latent_4x_indices)

  File "C:\sd\ComfyUI\custom_nodes\ComfyUI-FramePackWrapper_PlusOne\diffusers_helper\models\hunyuan_video_packed.py", line 840, in process_input_hidden_states
    clean_latents = self.gradient_checkpointing_method(self.clean_x_embedder.proj, clean_latents)

  File "C:\sd\ComfyUI\custom_nodes\ComfyUI-FramePackWrapper_PlusOne\diffusers_helper\models\hunyuan_video_packed.py", line 817, in gradient_checkpointing_method
    result = block(*args)

  File "C:\sd\ComfyUI\venv\lib\site-packages\torch\nn\modules\module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)

  File "C:\sd\ComfyUI\venv\lib\site-packages\torch\nn\modules\module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)

  File "C:\sd\ComfyUI\venv\lib\site-packages\torch\nn\modules\conv.py", line 725, in forward
    return self._conv_forward(input, self.weight, self.bias)

  File "C:\sd\ComfyUI\venv\lib\site-packages\torch\nn\modules\conv.py", line 720, in _conv_forward
    return F.conv3d(
```

</details>

The investigation revealed that the cause of the issue was that the mask's tensor dimensions became 6-dimensional during the mask conversion process.

Therefore, I made corrections so that the dimensions would be converted to 5-dimensional.

Thank you.